### PR TITLE
chore: shorten user identities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,14 +295,14 @@ workflows:
       #            - unit-test-nifikop
       #          <<: *canonical_repo_filter
 
-      - operator/release-helm:
-          name: release-helm-orange-incubator-nifikop
-          requires:
-            - build-nifikop
-          <<: *only_on_release_tag
+      # - operator/release-helm:
+      #     name: release-helm-orange-incubator-nifikop
+      #     requires:
+      #       - build-nifikop
+      #     <<: *only_on_release_tag
 
-      - deploy-website:
-          name: deploy-website
-          requires:
-            - build-nifikop
-          <<: *website_publish
+      # - deploy-website:
+      #     name: deploy-website
+      #     requires:
+      #       - build-nifikop
+      #     <<: *website_publish

--- a/pkg/pki/certmanagerpki/certmanager_pki_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki_test.go
@@ -72,7 +72,7 @@ func newCASecret() *corev1.Secret {
 
 func newPreCreatedSecret() *corev1.Secret {
 	secret := &corev1.Secret{}
-	secret.Name = "test-controller"
+	secret.Name = "test-c"
 	secret.Namespace = "test-namespace"
 	cert, key, _, _ := certutil.GenerateTestCert()
 	secret.Data = map[string][]byte{

--- a/pkg/pki/certmanagerpki/certmanager_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_test.go
@@ -39,7 +39,7 @@ func newMockCluster() *v1alpha1.NifiCluster {
 		{ContainerPort: 9092},
 	}
 	cluster.Spec.ListenersConfig.SSLSecrets = &v1alpha1.SSLSecrets{
-		TLSSecretName: "test-controller",
+		TLSSecretName: "test-c",
 		PKIBackend:    v1alpha1.PKIBackendCertManager,
 		Create:        true,
 	}

--- a/pkg/pki/certmanagerpki/certmanager_tls_config_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_tls_config_test.go
@@ -27,7 +27,7 @@ import (
 
 func newMockControllerSecret(valid bool) *corev1.Secret {
 	secret := &corev1.Secret{}
-	secret.Name = "test-controller"
+	secret.Name = "test-c"
 	secret.Namespace = "test-namespace"
 	cert, key, _, _ := certutil.GenerateTestCert()
 	if valid {

--- a/pkg/resources/nifi/nifi.go
+++ b/pkg/resources/nifi/nifi.go
@@ -697,10 +697,7 @@ func (r *Reconciler) reconcileNifiPod(log logr.Logger, desiredPod *corev1.Pod) (
 }
 
 func (r *Reconciler) reconcileNifiUsersAndGroups(log logr.Logger) error {
-	controllerName := types.NamespacedName{Name: fmt.Sprintf(pkicommon.NodeControllerFQDNTemplate,
-		fmt.Sprintf(pkicommon.NodeControllerTemplate, r.NifiCluster.Name),
-		r.NifiCluster.Namespace,
-		r.NifiCluster.Spec.ListenersConfig.GetClusterDomain()), Namespace: r.NifiCluster.Namespace}
+	controllerName := types.NamespacedName{Name: "admin-user", Namespace: r.NifiCluster.Namespace}
 
 	managedUsers := append(r.NifiCluster.Spec.ManagedAdminUsers, r.NifiCluster.Spec.ManagedReaderUsers...)
 	var users []*v1alpha1.NifiUser

--- a/pkg/resources/nifi/secretconfig.go
+++ b/pkg/resources/nifi/secretconfig.go
@@ -32,7 +32,6 @@ import (
 	"github.com/Orange-OpenSource/nifikop/pkg/resources/templates"
 	"github.com/Orange-OpenSource/nifikop/pkg/resources/templates/config"
 	"github.com/Orange-OpenSource/nifikop/pkg/util"
-	pkicommon "github.com/Orange-OpenSource/nifikop/pkg/util/pki"
 	utilpki "github.com/Orange-OpenSource/nifikop/pkg/util/pki"
 	"github.com/go-logr/logr"
 	"github.com/imdario/mergo"

--- a/pkg/resources/nifi/secretconfig.go
+++ b/pkg/resources/nifi/secretconfig.go
@@ -436,10 +436,7 @@ func (r *Reconciler) getAuthorizersConfigString(nConfig *v1alpha1.NodeConfig, id
 		"ClusterName": r.NifiCluster.Name,
 		"Namespace":   r.NifiCluster.Namespace,
 		"NodeList":    nodeList,
-		"ControllerUser": fmt.Sprintf(pkicommon.NodeControllerFQDNTemplate,
-			fmt.Sprintf(pkicommon.NodeControllerTemplate, r.NifiCluster.Name),
-			r.NifiCluster.Namespace,
-			r.NifiCluster.Spec.ListenersConfig.GetClusterDomain()),
+		"ControllerUser": "admin-user",
 	}); err != nil {
 		log.Error(err, "error occurred during parsing the config template")
 	}

--- a/pkg/util/nifi/common.go
+++ b/pkg/util/nifi/common.go
@@ -30,7 +30,7 @@ const (
 	// AllNodeServiceTemplate template for Nifi all nodes service
 	AllNodeServiceTemplate = "%s-all-node"
 	// HeadlessServiceTemplate template for Nifi headless service
-	HeadlessServiceTemplate = "%s-headless"
+	HeadlessServiceTemplate = "%s-h"
 
 	// TimeStampLayout defines the date format used.
 	TimeStampLayout = "Mon, 2 Jan 2006 15:04:05 GMT"

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -108,7 +108,7 @@ func GetInternalDNSNames(cluster *v1alpha1.NifiCluster, nodeId int32) (dnsNames 
 //}
 
 func GetNodeUserName(cluster *v1alpha1.NifiCluster, nodeId int32) string {
-	return fmt.Sprintf("node-%s-user", nodeId)
+	return fmt.Sprintf("node-%d-user", nodeId)
 }
 
 // clusterDNSNames returns all the possible DNS Names for a NiFi Cluster

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -108,8 +108,7 @@ func GetInternalDNSNames(cluster *v1alpha1.NifiCluster, nodeId int32) (dnsNames 
 //}
 
 func GetNodeUserName(cluster *v1alpha1.NifiCluster, nodeId int32) string {
-	return nifi.ComputeRequestNiFiNodeHostname(nodeId, cluster.Name, cluster.Namespace,
-		cluster.Spec.Service.HeadlessEnabled, cluster.Spec.ListenersConfig.GetClusterDomain(), cluster.Spec.ListenersConfig.UseExternalDNS)
+	return fmt.Sprintf("node-%s-user", nodeId)
 }
 
 // clusterDNSNames returns all the possible DNS Names for a NiFi Cluster
@@ -201,10 +200,7 @@ func nodeUserForClusterNode(cluster *v1alpha1.NifiCluster, nodeId int32, additio
 
 // ControllerUserForCluster returns a NifiUser CR for the controller/cc certificates in a NifiCluster
 func ControllerUserForCluster(cluster *v1alpha1.NifiCluster) *v1alpha1.NifiUser {
-	nodeControllerName := fmt.Sprintf(NodeControllerFQDNTemplate,
-		fmt.Sprintf(NodeControllerTemplate, cluster.Name),
-		cluster.Namespace,
-		cluster.Spec.ListenersConfig.GetClusterDomain())
+	nodeControllerName := "admin-user"
 	return &v1alpha1.NifiUser{
 		ObjectMeta: templates.ObjectMeta(
 			nodeControllerName,

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -38,7 +38,7 @@ const (
 	// NodeIssuerTemplate is the template used for node issuer resources
 	NodeIssuerTemplate = "%s-issuer"
 	// NodeControllerTemplate is the template used for operator certificate resources
-	NodeControllerTemplate = "%s-controller"
+	NodeControllerTemplate = "%s-c"
 	// NodeControllerFQDNTemplate is combined with the above and cluster namespace
 	// to create a 'fake' full-name for the controller user
 	NodeControllerFQDNTemplate = "%s.%s.mgt.%s"

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -149,10 +149,7 @@ func TestNodeUsersForCluster(t *testing.T) {
 func TestControllerUserForCluster(t *testing.T) {
 	cluster := testCluster(t)
 	user := ControllerUserForCluster(cluster)
-	nodeControllerName := fmt.Sprintf(NodeControllerFQDNTemplate,
-		fmt.Sprintf(NodeControllerTemplate, cluster.Name),
-		cluster.Namespace,
-		cluster.Spec.ListenersConfig.GetClusterDomain())
+	nodeControllerName := "admin-user"
 
 	expected := &v1alpha1.NifiUser{
 		ObjectMeta: templates.ObjectMeta(


### PR DESCRIPTION
No idea if this works. Attempts to convert `-headless` to `-h`, `-controller` to `-c`, and gives the default users short names like `admin-user` and `node-[n]-user`.