### PR TITLE
chore: support k8s <1.21 by using PDB from policy/v1beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ### Changed
 
-- [PR #75](https://github.com/konpyutaika/nifikop/pull/75) - **[Operator]** Update PodDisruptionBudget version to policy/v1 instead of policy/v1beta1.
-
 ### Deprecated
 
 ### Removed

--- a/controllers/nificluster_controller.go
+++ b/controllers/nificluster_controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/konpyutaika/nifikop/pkg/resources/nifi"
 	"github.com/konpyutaika/nifikop/pkg/util"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -193,7 +193,7 @@ func (r *NifiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *NifiClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.NifiCluster{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
+		Owns(&policyv1beta1.PodDisruptionBudget{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Pod{}).
 		Owns(&corev1.ConfigMap{}).

--- a/pkg/resources/nifi/poddisruptionbudget.go
+++ b/pkg/resources/nifi/poddisruptionbudget.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/konpyutaika/nifikop/pkg/resources/templates"
 	"github.com/konpyutaika/nifikop/pkg/util"
-	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -24,10 +24,10 @@ func (r *Reconciler) podDisruptionBudget(log logr.Logger) (runtimeClient.Object,
 
 	}
 
-	return &policyv1.PodDisruptionBudget{
+	return &policyv1beta1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
-			APIVersion: "policy/v1",
+			APIVersion: "policy/v1beta1",
 		},
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf("%s-pdb", r.NifiCluster.Name),
@@ -35,7 +35,7 @@ func (r *Reconciler) podDisruptionBudget(log logr.Logger) (runtimeClient.Object,
 			r.NifiCluster.Spec.Service.Annotations,
 			r.NifiCluster,
 		),
-		Spec: policyv1.PodDisruptionBudgetSpec{
+		Spec: policyv1beta1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: nifiutil.LabelsForNifi(r.NifiCluster.Name),


### PR DESCRIPTION
Helps https://github.com/influxdata/data-acquisition/issues/264

Reverts commit ca727e8f83869972271e7742cb9ae548cca3875a so our fork can continue to support k8s 1.20. 